### PR TITLE
fix(deis-slugbuilder.yaml,deis-store-secret.yaml): remove secret, use minio-user instead

### DIFF
--- a/manifests/deis-slugbuilder.yaml
+++ b/manifests/deis-slugbuilder.yaml
@@ -20,10 +20,10 @@ spec:
         - name : put_url
           value: "https://s3-us-west-1.amazonaws.com/myslug/tmp"
       volumeMounts:
-        - name: object-store
+        - name: minio-user
           mountPath: /var/run/secrets/object/store
           readOnly: true
   volumes:
-    - name: object-store
+    - name: minio-user
       secret:
-        secretName: object-store
+        secretName: minio-user

--- a/manifests/deis-store-secret.yaml
+++ b/manifests/deis-store-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: object-store
-  heritage: s3
-type: Opaque
-data:
-  access-key-id: QUtJQUpYSE5GS0xLUkY1TVE=
-  access-secret-key: UnYrQWtTa1E2OFRZUrY1ROUURMbGlnYkEzTGIwWWd4Z1I3MQ==


### PR DESCRIPTION
This PR is not critical for `v2.0-alpha1`, since [deis/builder](https://github.com/deis/builder) launches slugbuilders from its own manifest. This fix, however, corrects the manifest to match what Builder uses and the [Helm chart](https://github.com/deis/charts).
