### PR TITLE
chore(buildpacks): update heroku-buildpack-go to v31

### DIFF
--- a/rootfs/builder/install-buildpacks
+++ b/rootfs/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v94
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v66
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v30
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v31


### PR DESCRIPTION
Adds Go 1.6 support.
See https://github.com/heroku/heroku-buildpack-go/compare/v30...v31 and deis/deis#4944.
