### PR TITLE
fix(build.sh): rename DEBUG to DEIS_DEBUG, unset after use

### DIFF
--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-[[ $DEBUG ]] && set -x
+[[ $DEIS_DEBUG ]] && set -x
+unset DEIS_DEBUG
 
 app_dir=/app
 build_root=/tmp/build


### PR DESCRIPTION
Introducing DEBUG into the environment causes libraries like `hiredis` to install differently. We
should not be affecting the build environment in any way.

refs deis/builder#317
