### PR TITLE
chore(buildpacks): update heroku-buildpack-go to v40

### DIFF
--- a/rootfs/builder/install-buildpacks
+++ b/rootfs/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v102
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v70
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v37
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v40


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-go/compare/v37...v40 and also deis/deis#5038.
