### PR TITLE
chore(buildpacks): update heroku-buildpack-go to v41

### DIFF
--- a/rootfs/builder/install-buildpacks
+++ b/rootfs/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v102
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v70
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v40
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v41


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-go/compare/v40...v41

I tested this with [example-go](https://github.com/deis/example-go) on a GKE cluster with the current workflow-dev chart.
