### PR TITLE
feat(builder): add pre-compile/post-compile hooks

### DIFF
--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -141,11 +141,23 @@ else
     exit 1
 fi
 
+## Run pre-compile hook
+
+if [[ -f "$build_root/bin/pre-compile" ]]; then
+    "$build_root/bin/pre-compile"
+fi
+
 ## Buildpack compile
 
 "$selected_buildpack/bin/compile" "$build_root" "$cache_root" | ensure_indent
 
 "$selected_buildpack/bin/release" "$build_root" "$cache_root" > $build_root/.release
+
+## Run post-compile hook
+
+if [[ -f "$build_root/bin/post-compile" ]]; then
+    "$build_root/bin/post-compile"
+fi
 
 ## Display process types
 


### PR DESCRIPTION
Some users require a way to stop or check if a service is running before building an app, and sometimes notifying another service after the build is complete.

closes deis/deis#4579
