### PR TITLE
ref(Makefile): remove obsolete "docker tag -f" flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 
 docker-build:
 	docker build --rm -t ${IMAGE} rootfs
-	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 deploy: docker-build docker-push
 


### PR DESCRIPTION
This is an error with Docker 1.12.
