### PR TITLE
fix(build.sh): delay so stderr is logged before pod exits

### DIFF
--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+function sleep_before_exit {
+	# delay before exiting, so stdout/stderr flushes through the logging system
+	sleep 3
+}
+trap sleep_before_exit EXIT
+
 [[ $DEIS_DEBUG ]] && set -x
 unset DEIS_DEBUG
 
@@ -19,7 +25,6 @@ if ! [[ -z "${TAR_PATH}" ]]; then
 	tar -xzf /tmp/slug.tgz -C /app/
 	unset TAR_PATH
 fi
-
 
 if [[ "$1" == "-" ]]; then
     slug_file="$1"


### PR DESCRIPTION
Output for `git push` with a bad buildpack would sometimes fail to show the relevant buildpack compile output and instead log the json for a Kubernetes pod error, similarly to deis/dockerbuilder#76.

Introducing a small delay before exiting seems to fix the output such that deis/workflow-e2e#258 passes consistently. I ran `gingko -untilItFails` until neither of us could stand it:

``` console
$ GINKGO_NODES=20 FOCUS_TEST="with a bad buildpack" make test-integration
ginkgo -slowSpecThreshold=120.00 -noisyPendings=false -v -untilItFails -nodes=20 --skip="all (buildpack|dockerfile) apps" --focus="with a bad buildpack" tests/
Running Suite: Deis Workflow
============================
Random Seed: 1468530009
Will run 2 of 304 specs

Running in parallel across 20 nodes

...

Ran 2 of 304 Specs in 19.857 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 302 Skipped 

All tests passed...
Will keep running them until they fail.
This was attempt #44
No, seriously... you can probably stop now.
^C
```

Fixes #93.
Unblocks deis/workflow-e2e#258.
