### PR TITLE
chore(buildpacks): update heroku-buildpack-go to v46

### DIFF
--- a/rootfs/builder/install-buildpacks
+++ b/rootfs/builder/install-buildpacks
@@ -39,4 +39,4 @@ download_buildpack https://github.com/heroku/heroku-buildpack-python.git        
 download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v109
 download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v72
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v44
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v46


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-go/compare/v44...v46

I tested this with [example-go](https://github.com/deis/example-go). It silences the warning about Go 1.7beta2 that was present in deis/example-go#17:

``` bash
Starting build... but first, coffee!
-----> Go app detected
-----> Checking Godeps/Godeps.json file.
-----> Installing go1.7... done
-----> Running: go install -v -tags heroku .
       github.com/deis/example-go
-----> Discovering process types
       Procfile declares types -> web
-----> Compiled slug size is 1.9M
Build complete.
Launching App...
...
...
...
Done, frisky-barbecue:v2 deployed to Workflow
```
