### PR TITLE
fix(build): check if release yaml is nil before accessing hash

### DIFF
--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -166,7 +166,7 @@ if [[ -f "$build_root/Procfile" ]]; then
 fi
 default_types=""
 if [[ -s "$build_root/.release" ]]; then
-    default_types=$(ruby -e "require 'yaml';puts (YAML.load_file('$build_root/.release')['default_process_types'] || {}).keys().join(', ')")
+    default_types=$(ruby -e "require 'yaml';puts ((YAML.load_file('$build_root/.release') || {})['default_process_types'] || {}).keys().join(', ')")
     [[ $default_types ]] && echo_normal "Default process types for $buildpack_name -> $default_types"
 fi
 
@@ -184,7 +184,7 @@ else
 fi
 
 if [[ ! -f "$build_root/Procfile" ]]; then
-	if [[ -s "$build_root/.release" ]]; then
+	if [[ -s "$build_root/.release" ]] && [[ $default_types ]]; then
 		ruby -e "require 'yaml';procTypes = (YAML.load_file('$build_root/.release')['default_process_types']);open('$build_root/Procfile','w') {|f| YAML.dump(procTypes,f)}"
 	else
 		echo "{}" > $build_root/Procfile


### PR DESCRIPTION
Fixes #103 

This can be tested with the example-java-jetty app with 
`BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-java.git#v46`

This also requires deis/slugrunner#50, where the same error comes up in the slugrunner.
