### PR TITLE
feat(Makefile): add --pull flag to docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:
 	@echo Nothing to do.
 
 docker-build:
-	docker build --rm -t ${IMAGE} rootfs
+	docker build --pull --rm -t ${IMAGE} rootfs
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 deploy: docker-build docker-push


### PR DESCRIPTION
This feature flag forces the daemon to pull the upstream image before building, ensuring we are always up to date.
