### PR TITLE
define name of buildpack on download to determine order of use

### DIFF
--- a/rootfs/builder/install-buildpacks
+++ b/rootfs/builder/install-buildpacks
@@ -5,8 +5,8 @@ BUILDPACK_INSTALL_PATH="/tmp/buildpacks"
 
 download_buildpack() {
     buildpack_url="$1"
-    buildpack_name=$(basename "$buildpack_url")
     buildpack_commit="$2"
+    buildpack_name="$3"
 
     echo "Fetching $buildpack_name..."
 
@@ -28,15 +28,15 @@ download_buildpack() {
 
 mkdir -p $BUILDPACK_INSTALL_PATH
 
-download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          v1.0.0
-download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v150
-download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v93
-download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v48
-download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v19
-download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v21
-download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26
-download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v97
-download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v117
-download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v72
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v54
+download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          v1.0.0   01-multi
+download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v75      02-clojure
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v54      03-go
+download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v19      04-gradle
+download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v21      05-grails
+download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v48      06-java
+download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v93      07-nodejs
+download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v117     08-php
+download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26      09-play
+download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v97      10-python
+download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v150     11-ruby
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v72      12-scala


### PR DESCRIPTION
I think it's necessary for "multi-build" because on this [loop](https://github.com/deis/slugbuilder/blob/master/rootfs/builder/build.sh#L157-L159) the detection is made in alphabetic order (e.g. in a "multi build" with golang build and apt build the slugbuilder detects a golang build before detects the "multi-build")