### PR TITLE
chore(Dockerfile): switch to heroku-16 stack

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM heroku/cedar:14
+FROM heroku/heroku:16
 
 RUN mkdir /app
 RUN addgroup --quiet --gid 2000 slug && \

--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -97,7 +97,7 @@ export APP_DIR="$app_dir"
 export HOME="$app_dir"
 REQUEST_ID=$(openssl rand -base64 32)
 export REQUEST_ID
-export STACK=cedar-14
+export STACK=heroku-16
 
 ## copy the environment dir excluding the ephemeral ..data/ dir and other symlinks created by Kubernetes.
 


### PR DESCRIPTION
The heroku-16 stack has now become the default stack on Heroku. See https://devcenter.heroku.com/changelog-items/1139 for more information.