### PR TITLE
feat(normalize_storage): use `MINIO_BUCKET` env-var

### DIFF
--- a/rootfs/bin/normalize_storage
+++ b/rootfs/bin/normalize_storage
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 export BUCKET_FILE=/var/run/secrets/deis/objectstore/creds/builder-bucket
 if [ "$BUILDER_STORAGE" == "minio" ]; then
+  MINIO_BUCKET_NAME=${MINIO_BUCKET:-git}
   mkdir -p /app/objectstore/minio/
-  echo "git" > /app/objectstore/minio/builder-bucket
+  echo "$MINIO_BUCKET_NAME" > /app/objectstore/minio/builder-bucket
   export BUCKET_FILE=/app/objectstore/minio/builder-bucket
 elif [ "$BUILDER_STORAGE" == "azure" ] || [ "$BUILDER_STORAGE" == "swift" ] ; then
   export CONTAINER_FILE=/var/run/secrets/deis/objectstore/creds/builder-container


### PR DESCRIPTION
Use MINIO_BUCKET environment variable to define the bucket name for minio storage type
instead of hardcoded `git`

If there isnt a value on MINIO_BUCKET var, normalize_storage will use `git` by default